### PR TITLE
Update README.md added go get to fix #609 see https://github.com/cucumber/godog/issues/609

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
         ctx.Then(`^there should be (\d+) remaining$`, thereShouldBeRemaining)
 }
 ```
-
+Load the packages with `go get github.com/cucumber/godog` 
 Our module should now look like this:
 ```
 godogs
 - features
   - godogs.feature
 - go.mod
-- go.sum
+- go.sum 
 - godogs_test.go
 ```
 


### PR DESCRIPTION
The command `go get github.com/cucumber/godogsteps` is missing and this will lead to ohter errors later. So if you add this line then the rest should be as expected. Although im do not know if `sum.go` is creating after `go get ...` or after the next command `go test`